### PR TITLE
Add authorship to files where it was missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,10 @@ jack_playrec help
  csOutputPorts, and the number of channels in y will match the
  number of channels in csInputPorts. If the argument is a numeric
  vector, then the physical ports (starting from 1) are used.
+
+
+
+jack_playrec was isolated and renamed from the tascar_jackio tool of
+the Toolbox for Acoustic Scene Creation and Rendering TASCAR
+([https://github.com/HoerTech-gGmbH/tascar](https://github.com/HoerTech-gGmbH/tascar)),
+written by Giso Grimm.

--- a/cli.cc
+++ b/cli.cc
@@ -1,5 +1,6 @@
 // This file is part of jack_playrec
 // Copyright (C) 2018  Hörtech gGmbH
+// Copyright (C) 2014 2015 2018 Giso Grimm
 //
 //  This program is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/cli.h
+++ b/cli.h
@@ -1,5 +1,6 @@
 // This file is part of jack_playrec
 // Copyright (C) 2018  Hörtech gGmbH
+// Copyright (C) 2014 2015 2018 Giso Grimm
 //
 //  This program is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/errorhandling.cc
+++ b/errorhandling.cc
@@ -1,5 +1,6 @@
 // This file is part of jack_playrec
 // Copyright (C) 2018  Hörtech gGmbH
+// Copyright (C) 2014 2015 2018 Giso Grimm
 //
 //  This program is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/errorhandling.h
+++ b/errorhandling.h
@@ -1,5 +1,6 @@
 // This file is part of jack_playrec
 // Copyright (C) 2018  Hörtech gGmbH
+// Copyright (C) 2014 2015 2018 Giso Grimm
 //
 //  This program is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/jack_par.cc
+++ b/jack_par.cc
@@ -1,7 +1,7 @@
 // jack_par prints jack parameters (bufsize, samplerate)
 // This file is part of jack_playrec
 // Copyright (C) 2018  Hörtech gGmbH
-// Copyright (C) 2016 Giso Grimm, Carl-von-Ossietzky Universitaet Oldenburg
+// Copyright (C) 2014 2015 2016 Giso Grimm, Carl-von-Ossietzky Universitaet Oldenburg
 //
 //  This program is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/jack_playrec.cc
+++ b/jack_playrec.cc
@@ -1,5 +1,6 @@
 // This file is part of jack_playrec
 // Copyright (C) 2018  Hörtech gGmbH
+// Copyright (C) 2014 2015 2018 Giso Grimm
 //
 //  This program is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/jack_playrec.m
+++ b/jack_playrec.m
@@ -1,6 +1,6 @@
 % This file is part of jack_playrec
 % Copyright (C) 2018  Hörtech gGmbH
-% Copyright (C) 2013  Giso Grimm
+% Copyright (C) 2013 2014 2015 2016 2017 Giso Grimm
 %
 %  This program is free software: you can redistribute it and/or modify
 %  it under the terms of the GNU General Public License as published by

--- a/jackclient.cc
+++ b/jackclient.cc
@@ -1,5 +1,6 @@
 // This file is part of jack_playrec
 // Copyright (C) 2018  Hörtech gGmbH
+// Copyright (C) 2014 2015 2018 Giso Grimm
 //
 //  This program is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/parse_keyval.m
+++ b/parse_keyval.m
@@ -1,5 +1,6 @@
 % This file is part of jack_playrec
 % Copyright (C) 2018  Hörtech gGmbH
+% Copyright (C) 2014 2015 Giso Grimm
 %
 %  This program is free software: you can redistribute it and/or modify
 %  it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
I suggest to add the missing authorships in all source files. Also it would be good to add a comment on the origin of this tool, so users may trace it back.